### PR TITLE
SOLAS-5225: As a DEVELOPER I am able to publish the component to npm in an efficient manner

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 ##################
 node_modules
 .log
+dist
 
 # OS generated files #
 ##################

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ We use [Semantic Versioning](http://semver.org/) and bump versions using the `np
 hooks in `package.json`.
 
 ## How to release a new version
-1. Make sure to be clear on what kind of version it is (`patch`, `minor` or `major`). Create a new version:
+1. You should only publish the master branch. Make sure to be clear on what kind of version it is (`patch`, `minor` or `major`). Create a new version:
 ```
 npm version patch
 ```
@@ -40,6 +40,7 @@ Example:
 ```
 npm publish ./
 ```
+4. Go back to master branch and push it
 
 ## Credits
 

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ npm test -- --watch
 ```
 
 ### Releasing
-We use [Semantic Versioning](http://semver.org/) and bump versions using the `npm version` command ([see npm docs](https://docs.npmjs.com/cli/version)). We've defined `preversion`, `version` and `postversion`
+We use [Semantic Versioning](http://semver.org/) and bump versions using the `npm version` command ([see npm docs](https://docs.npmjs.com/cli/version)). We've defined `preversion` and `postversion`
 hooks in `package.json`.
 
 ## How to release a new version

--- a/README.md
+++ b/README.md
@@ -29,12 +29,12 @@ npm version patch
 ```
 This transpiles the source files to ES5 using babel. The version is bumped and committed to both master and in the `dist` branch (which is an orphan branch that only includes the files we want to distribute). You'll be left in the `dist` branch.
 
-2. Do a `git log` to check that the version number is correct. Test that the version works correctly. Push to GitHub:
+2. Ensure you are in the `dist` branch. Do a `git log` to check that the version number is correct. Test that the version works correctly. When you're confident, push to GitHub:
 ```
 git push origin && git push origin --tags
 ```
 
-3. Publish to npm:
+3. Again, make sure you are still in the `dist` branch. Publish to npm:
 
 Example:
 ```

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ We use [Semantic Versioning](http://semver.org/) and bump versions using the `np
 hooks in `package.json`.
 
 ## How to release a new version
-1. Create a new version:
+1. Make sure to be clear on what kind of version it is (`patch`, `minor` or `major`). Create a new version:
 ```
 npm version patch
 ```

--- a/README.md
+++ b/README.md
@@ -18,6 +18,28 @@ open http://localhost:3000
 npm test -- --watch
 ```
 
+### Releasing
+We use [Semantic Versioning](http://semver.org/) and bump versions using the `npm version` command ([see npm docs](https://docs.npmjs.com/cli/version)). We've defined `preversion`, `version` and `postversion`
+hooks in `package.json`.
+
+Releasing is a two step process. First we create a new version. Then we publish it.
+
+Example:
+```
+npm version patch -m "Bug fix..."
+```
+
+This will:
+
+1. Transpile the source files to ES5 using babel.
+2. Change to the `dist` branch (which is an orphan branch that only includes the files we want to distribute).
+3. Bump the version in package.json, commit and tag the release.
+
+Check that you're in the `dist` branch and that the commit has been made. To publish, run:
+```
+npm publish ./
+```
+
 ## Credits
 
 webpack setup based on [React Hot Boilerplate](https://github.com/gaearon/react-hot-boilerplate).

--- a/README.md
+++ b/README.md
@@ -22,20 +22,21 @@ npm test -- --watch
 We use [Semantic Versioning](http://semver.org/) and bump versions using the `npm version` command ([see npm docs](https://docs.npmjs.com/cli/version)). We've defined `preversion`, `version` and `postversion`
 hooks in `package.json`.
 
-Releasing is a two step process. First we create a new version. Then we publish it.
+## How to release a new version
+1. Create a new version:
+```
+npm version patch
+```
+This transpiles the source files to ES5 using babel. The version is bumped and committed to both master and in the `dist` branch (which is an orphan branch that only includes the files we want to distribute). You'll be left in the `dist` branch.
+
+2. Do a `git log` to check that the version number is correct. Test that the version works correctly. Push to GitHub:
+```
+git push origin && git push origin --tags
+```
+
+3. Publish to npm:
 
 Example:
-```
-npm version patch -m "Bug fix..."
-```
-
-This will:
-
-1. Transpile the source files to ES5 using babel.
-2. Change to the `dist` branch (which is an orphan branch that only includes the files we want to distribute).
-3. Bump the version in package.json, commit and tag the release.
-
-Check that you're in the `dist` branch and that the commit has been made. To publish, run:
 ```
 npm publish ./
 ```

--- a/demo/App.js
+++ b/demo/App.js
@@ -1,5 +1,5 @@
 import React, { Component } from 'react'
-import QuizContainer from '../src/QuizContainer'
+import QuizContainer from '../src'
 import questions from './questions'
 
 export default class App extends Component {

--- a/package.json
+++ b/package.json
@@ -6,9 +6,10 @@
     "start": "node server.js",
     "test": "NODE_ENV=test BABEL_DISABLE_CACHE=1 WEBPACK_RUNTIME_CONFIG=`pwd`/runtime.webpack.config ava",
     "build": "rm -rf dist;babel src --out-dir dist",
+    "getversion": "node -p -e \"require('./package.json').version\"",
     "preversion": "npm run build",
     "version": "git add .",
-    "postversion": "cp package.json dist && cp *.md dist && git checkout dist && cp -a ./dist/ . && git add . && git commit -m 'Version'"
+    "postversion": "cp package.json dist && cp *.md dist && git checkout dist && cp -a ./dist/ . && git add . && git commit -m $(npm run getversion --loglevel silent)"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -6,9 +6,9 @@
     "start": "node server.js",
     "test": "NODE_ENV=test BABEL_DISABLE_CACHE=1 WEBPACK_RUNTIME_CONFIG=`pwd`/runtime.webpack.config ava",
     "build": "rm -rf dist;babel src --out-dir dist",
-    "preversion": "npm run build && git checkout dist",
-    "version": "cp -a ./dist/ . && git add .",
-    "postversion": "git push origin dist && git push origin dist --tags"
+    "preversion": "npm run build",
+    "version": "git add .",
+    "postversion": "git checkout dist && cp -a ./dist/ . && git add . && git commit -m 'Version'"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -5,9 +5,9 @@
   "scripts": {
     "start": "node server.js",
     "test": "NODE_ENV=test BABEL_DISABLE_CACHE=1 WEBPACK_RUNTIME_CONFIG=`pwd`/runtime.webpack.config ava",
-    "build": "rm -rf dist;babel src --out-dir dist",
+    "build": "./scripts/build.sh",
     "preversion": "npm test",
-    "postversion": "npm run build && ./scripts/postversion.sh"
+    "postversion": "./scripts/postversion.sh"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -6,10 +6,9 @@
     "start": "node server.js",
     "test": "NODE_ENV=test BABEL_DISABLE_CACHE=1 WEBPACK_RUNTIME_CONFIG=`pwd`/runtime.webpack.config ava",
     "build": "rm -rf dist;babel src --out-dir dist",
-    "getversion": "node -p -e \"require('./package.json').version\"",
     "preversion": "npm run build",
     "version": "git add .",
-    "postversion": "cp package.json dist && cp *.md dist && git checkout dist && cp -a ./dist/ . && git add . && git commit -m $(npm run getversion --loglevel silent)"
+    "postversion": "./scripts/postversion.sh"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,10 +1,14 @@
 {
   "name": "react-quiz",
-  "version": "1.0.0",
+  "version": "0.0.1",
   "description": "Quiz component",
   "scripts": {
     "start": "node server.js",
-    "test": "NODE_ENV=test BABEL_DISABLE_CACHE=1 WEBPACK_RUNTIME_CONFIG=`pwd`/runtime.webpack.config ava"
+    "test": "NODE_ENV=test BABEL_DISABLE_CACHE=1 WEBPACK_RUNTIME_CONFIG=`pwd`/runtime.webpack.config ava",
+    "build": "rm -rf dist;babel src --out-dir dist",
+    "preversion": "npm run build && git checkout dist",
+    "version": "cp -a ./dist/ . && git add .",
+    "postversion": "git push origin dist && git push origin dist --tags"
   },
   "repository": {
     "type": "git",
@@ -18,17 +22,16 @@
   "author": "British Council",
   "license": "MIT",
   "devDependencies": {
-    "react": "^15.0.2",
-    "react-dom": "^15.0.2",
     "ava": "^0.14.0",
+    "babel-cli": "^6.10.1",
     "babel-core": "^6.0.20",
     "babel-eslint": "^4.1.3",
     "babel-loader": "^6.0.1",
     "babel-plugin-webpack-loaders": "^0.4.0",
     "babel-polyfill": "^6.8.0",
-    "babel-preset-es2015": "^6.0.15",
-    "babel-preset-react": "^6.0.15",
-    "babel-preset-stage-0": "^6.0.15",
+    "babel-preset-es2015": "^6.9.0",
+    "babel-preset-react": "^6.11.1",
+    "babel-preset-stage-0": "^6.5.0",
     "babel-register": "^6.8.0",
     "enzyme": "^2.2.0",
     "eslint": "^2.9.0",
@@ -36,7 +39,9 @@
     "eslint-plugin-promise": "^1.1.0",
     "eslint-plugin-react": "^3.16.1",
     "eslint-plugin-standard": "^1.3.2",
+    "react": "^15.0.2",
     "react-addons-test-utils": "^15.0.2",
+    "react-dom": "^15.0.2",
     "react-hot-loader": "^1.3.0",
     "webpack": "^1.13.0",
     "webpack-dev-server": "^1.12.1"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-quiz",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "description": "Quiz component",
   "scripts": {
     "start": "node server.js",

--- a/package.json
+++ b/package.json
@@ -6,9 +6,8 @@
     "start": "node server.js",
     "test": "NODE_ENV=test BABEL_DISABLE_CACHE=1 WEBPACK_RUNTIME_CONFIG=`pwd`/runtime.webpack.config ava",
     "build": "rm -rf dist;babel src --out-dir dist",
-    "preversion": "npm run build",
-    "version": "git add .",
-    "postversion": "./scripts/postversion.sh"
+    "preversion": "npm test",
+    "postversion": "npm run build && ./scripts/postversion.sh"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-quiz",
-  "version": "0.0.1",
+  "version": "0.0.3",
   "description": "Quiz component",
   "scripts": {
     "start": "node server.js",
@@ -8,7 +8,7 @@
     "build": "rm -rf dist;babel src --out-dir dist",
     "preversion": "npm run build",
     "version": "git add .",
-    "postversion": "git checkout dist && cp -a ./dist/ . && git add . && git commit -m 'Version'"
+    "postversion": "cp package.json dist && cp *.md dist && git checkout dist && cp -a ./dist/ . && git add . && git commit -m 'Version'"
   },
   "repository": {
     "type": "git",

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+echo "-- Building src files to dist directory"
+rm -rf dist
+babel src --out-dir dist
+
+echo "-- Copying additional files to dist directory"
+cp package.json dist
+cp *.md dist

--- a/scripts/postversion.sh
+++ b/scripts/postversion.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+cp package.json dist
+cp *.md dist
+git checkout dist
+cp -a ./dist/ .
+git add .
+git commit -m $(node -p -e "require('./package.json').version")

--- a/scripts/postversion.sh
+++ b/scripts/postversion.sh
@@ -1,14 +1,12 @@
 #!/bin/bash
-echo "-- Copy files to dist directory"
-cp package.json dist
-cp *.md dist
+npm run build
 
-echo "-- Switch to dist branch"
+echo "-- Switching to dist branch"
 git checkout dist || git checkout -b dist
 git fetch
 git reset --hard origin/dist
 
-echo "-- Commit the new version"
+echo "-- Committing the new version"
 cp -a ./dist/ .
 git add .
 git commit -m $(node -p -e "require('./package.json').version")

--- a/scripts/postversion.sh
+++ b/scripts/postversion.sh
@@ -1,7 +1,14 @@
 #!/bin/bash
+echo "-- Copy files to dist directory"
 cp package.json dist
 cp *.md dist
-git checkout dist
+
+echo "-- Switch to dist branch"
+git checkout dist || git checkout -b dist
+git fetch
+git reset --hard origin/dist
+
+echo "-- Commit the new version"
 cp -a ./dist/ .
 git add .
 git commit -m $(node -p -e "require('./package.json').version")

--- a/src/index.js
+++ b/src/index.js
@@ -1,0 +1,4 @@
+import QuizContainer from './QuizContainer'
+
+export { default as Quiz } from './Quiz'
+export default QuizContainer


### PR DESCRIPTION
https://bcdigital.atlassian.net/browse/SOLAS-5225

Adds the ability to publish the component to npm. See instructions in `README.md`. Adds  an `index.js` entry file that exports the `QuizContainer` component by default and `Quiz` for those who would like to write their own container component.

You can find the published component at https://www.npmjs.com/package/react-quiz
## Testing

You can try publishing a `patch` version yourself to verify that it works. We're currently on `v0.0.3` (so you would publish `v0.0.4`). After we've merged this branch we can release `1.0.0`.
