### PR TITLE
Ability to customise text

### DIFF
--- a/demo/App.js
+++ b/demo/App.js
@@ -2,6 +2,9 @@ import React, { Component } from 'react'
 import QuizContainer from '../src'
 import questions from './questions'
 
+// You can pass custom classNames in. Useful if you want to add your own CSS
+// classes to elements. The className will be appended to the existing one.
+// (Alternatively you can select on these selectors in your CSS to add styling.)
 const customClassNames = {
   'rq-Quiz-buttonContainer': '',
   'rq-Question-instruction': 'instruction',
@@ -14,12 +17,20 @@ const customClassNames = {
   'rq-Quiz-nextButton': 'btn btn-primary pull-right'
 }
 
+// You can override text in a similar way, e.g. if you want to translate the
+// component to different languages.
+const customText = {
+  // 'rq-Quiz-progressText': 'Question {n} of {total}',
+  // 'rq-Quiz-nextButton': 'Onwards',
+  // 'rq-Quiz-nextButton--finish': 'Enough of this I say!'
+}
+
 export default class App extends Component {
   render () {
     return (
       <div className="App">
         <QuizContainer customClassNames={customClassNames}
-                       progressTextTemplate="Question {n} of {total}"
+                       customText={customText}
                        questions={questions}
                        onFinish={(answers) => console.log(answers)} />
       </div>

--- a/src/Answer.js
+++ b/src/Answer.js
@@ -1,15 +1,21 @@
 import React from 'react'
 import classNames from 'classnames'
 
-const Answer = ({ active, onClick, children, customClassNames = {} }) => (
-  <li className={classNames('rq-Answer', customClassNames['rq-Answer'])}>
-    <button onClick={onClick}
-            className={classNames('rq-Answer-button', customClassNames['rq-Answer-button'],
-              { 'rq-Answer-button--active': active,
-                [customClassNames['rq-Answer-button--active']]: active
-              })}>{children}</button>
-  </li>
-)
+const Answer = ({ active, onClick, children, customClassNames = {} }) => {
+  const answerClassName = classNames('rq-Answer', customClassNames['rq-Answer'])
+  const answerButtonClassName = classNames('rq-Answer-button',
+    customClassNames['rq-Answer-button'],
+    { 'rq-Answer-button--active': active,
+      [customClassNames['rq-Answer-button--active']]: active
+    })
+
+  return (
+    <li className={answerClassName}>
+      <button onClick={onClick}
+              className={answerButtonClassName}>{children}</button>
+    </li>
+  )
+}
 
 Answer.propTypes = {
   active: React.PropTypes.bool.isRequired,

--- a/src/ProgressBar.js
+++ b/src/ProgressBar.js
@@ -6,10 +6,13 @@ const ProgressBar = ({ min = 0, max = 100, value = 0, customClassNames = {} }) =
     width: ((value - min) / (max - min) * 100) + '%'
   }
 
+  const progressBarClassName = classNames('rq-ProgressBar', customClassNames['rq-ProgressBar'])
+  const progressBarInnerClassName = classNames('rq-ProgressBar-inner', customClassNames['rq-ProgressBar-inner'])
+
   // Displays the progress bar size accordingly max, min, current value and isVisible
   return (
-    <div className={classNames('rq-ProgressBar', customClassNames['rq-ProgressBar'])}>
-      <div className={classNames('rq-ProgressBar-inner', customClassNames['rq-ProgressBar-inner'])} role="progressbar"
+    <div className={progressBarClassName}>
+      <div className={progressBarInnerClassName} role="progressbar"
            aria-valuenow={value} aria-valuemin={min} aria-valuemax={max}
            style={progressSize}>
       </div>

--- a/src/Question.js
+++ b/src/Question.js
@@ -3,20 +3,25 @@ import Answer from './Answer'
 import classNames from 'classnames'
 
 const Question = ({ instruction, text, answers, selectedAnswer, onAnswer,
-  customClassNames = {} }) => (
-  <div>
-    <p className={classNames('rq-Question-instruction', customClassNames['rq-Question-instruction'])}>{instruction}</p>
-    <p>{text}</p>
-    <ol className={classNames('rq-Question-answerList', customClassNames['rq-Question-answerList'])}>
-      {answers.map((a, i) => (
-        <Answer customClassNames={customClassNames}
-                key={i}
-                active={i === selectedAnswer}
-                onClick={() => onAnswer(i)}>{a}</Answer>
-      ))}
-    </ol>
-  </div>
-)
+  customClassNames = {} }) => {
+  const instructionClassName = classNames('rq-Question-instruction', customClassNames['rq-Question-instruction'])
+  const answerListClassName = classNames('rq-Question-answerList', customClassNames['rq-Question-answerList'])
+
+  return (
+    <div>
+      <p className={instructionClassName}>{instruction}</p>
+      <p>{text}</p>
+      <ol className={answerListClassName}>
+        {answers.map((a, i) => (
+          <Answer customClassNames={customClassNames}
+                  key={i}
+                  active={i === selectedAnswer}
+                  onClick={() => onAnswer(i)}>{a}</Answer>
+        ))}
+      </ol>
+    </div>
+  )
+}
 
 Question.propTypes = {
   instruction: React.PropTypes.string,

--- a/src/Quiz.js
+++ b/src/Quiz.js
@@ -6,7 +6,7 @@ import interpolate from 'interpolate'
 
 const Quiz = ({ questions, answers, currentQuestionIndex, onAnswer,
   onNext, onFinish, progressTextTemplate = 'Question {n} of {total}',
-  customClassNames = {} }) => {
+  customClassNames = {}, text = {}}) => {
   const isLastQuestion = (currentQuestionIndex + 1) === questions.length
 
   return (
@@ -26,10 +26,10 @@ const Quiz = ({ questions, answers, currentQuestionIndex, onAnswer,
         {isLastQuestion
           ? <button className={classNames('rq-Quiz-nextButton', customClassNames['rq-Quiz-nextButton'])}
                     onClick={() => onFinish(answers)}
-                    disabled={answers[currentQuestionIndex] === undefined}>Finish</button>
+                    disabled={answers[currentQuestionIndex] === undefined}>{text['rq-Quiz-nextButton--finish'] || 'Finish'}</button>
           : <button className={classNames('rq-Quiz-nextButton', customClassNames['rq-Quiz-nextButton'])}
                     onClick={onNext}
-                    disabled={answers[currentQuestionIndex] === undefined}>Next</button>
+                    disabled={answers[currentQuestionIndex] === undefined}>{text['rq-Quiz-nextButton'] || 'Next'}</button>
         }
       </div>
     </div>

--- a/src/Quiz.js
+++ b/src/Quiz.js
@@ -4,17 +4,18 @@ import ProgressBar from './ProgressBar'
 import classNames from 'classnames'
 import interpolate from 'interpolate'
 
-const Quiz = ({ questions, answers, currentQuestionIndex, onAnswer,
-  onNext, onFinish, progressTextTemplate = 'Question {n} of {total}',
-  customClassNames = {}, text = {}}) => {
+const Quiz = ({ questions, answers, currentQuestionIndex, onAnswer, onNext,
+  onFinish, customClassNames = {}, customText = {}}) => {
   const isLastQuestion = (currentQuestionIndex + 1) === questions.length
 
   return (
     <div>
-      <p>{interpolate(progressTextTemplate, {
-        n: currentQuestionIndex + 1,
-        total: questions.length
-      })}</p>
+      <p className={classNames('rq-Quiz-progressText', customClassNames['rq-Quiz-progressText'])}>
+        {interpolate(customText['rq-Quiz-progressText'] || 'Question {n} of {total}', {
+          n: currentQuestionIndex + 1,
+          total: questions.length
+        })}
+      </p>
       <ProgressBar value={currentQuestionIndex + 1}
                    max={questions.length}
                    customClassNames={customClassNames} />
@@ -26,10 +27,10 @@ const Quiz = ({ questions, answers, currentQuestionIndex, onAnswer,
         {isLastQuestion
           ? <button className={classNames('rq-Quiz-nextButton', customClassNames['rq-Quiz-nextButton'])}
                     onClick={() => onFinish(answers)}
-                    disabled={answers[currentQuestionIndex] === undefined}>{text['rq-Quiz-nextButton--finish'] || 'Finish'}</button>
+                    disabled={answers[currentQuestionIndex] === undefined}>{customText['rq-Quiz-nextButton--finish'] || 'Finish'}</button>
           : <button className={classNames('rq-Quiz-nextButton', customClassNames['rq-Quiz-nextButton'])}
                     onClick={onNext}
-                    disabled={answers[currentQuestionIndex] === undefined}>{text['rq-Quiz-nextButton'] || 'Next'}</button>
+                    disabled={answers[currentQuestionIndex] === undefined}>{customText['rq-Quiz-nextButton'] || 'Next'}</button>
         }
       </div>
     </div>

--- a/src/Quiz.js
+++ b/src/Quiz.js
@@ -8,14 +8,20 @@ const Quiz = ({ questions, answers, currentQuestionIndex, onAnswer, onNext,
   onFinish, customClassNames = {}, customText = {}}) => {
   const isLastQuestion = (currentQuestionIndex + 1) === questions.length
 
+  const progressTextClassName = classNames('rq-Quiz-progressText', customClassNames['rq-Quiz-progressText'])
+  const buttonContainerClassName = classNames('rq-Quiz-buttonContainer', customClassNames['rq-Quiz-buttonContainer'])
+  const nextButtonClassName = classNames('rq-Quiz-nextButton', customClassNames['rq-Quiz-nextButton'])
+
+  const finishButtonText = customText['rq-Quiz-nextButton--finish'] || 'Finish'
+  const nextButtonText = customText['rq-Quiz-nextButton'] || 'Next'
+  const progressText = interpolate(customText['rq-Quiz-progressText'] || 'Question {n} of {total}', {
+    n: currentQuestionIndex + 1,
+    total: questions.length
+  })
+
   return (
     <div>
-      <p className={classNames('rq-Quiz-progressText', customClassNames['rq-Quiz-progressText'])}>
-        {interpolate(customText['rq-Quiz-progressText'] || 'Question {n} of {total}', {
-          n: currentQuestionIndex + 1,
-          total: questions.length
-        })}
-      </p>
+      <p className={progressTextClassName}>{progressText}</p>
       <ProgressBar value={currentQuestionIndex + 1}
                    max={questions.length}
                    customClassNames={customClassNames} />
@@ -23,14 +29,14 @@ const Quiz = ({ questions, answers, currentQuestionIndex, onAnswer, onNext,
                 onAnswer={onAnswer}
                 selectedAnswer={answers[currentQuestionIndex]}
                 {...questions[currentQuestionIndex]} />
-      <div className={classNames('rq-Quiz-buttonContainer', customClassNames['rq-Quiz-buttonContainer'])}>
+      <div className={buttonContainerClassName}>
         {isLastQuestion
-          ? <button className={classNames('rq-Quiz-nextButton', customClassNames['rq-Quiz-nextButton'])}
+          ? <button className={nextButtonClassName}
                     onClick={() => onFinish(answers)}
-                    disabled={answers[currentQuestionIndex] === undefined}>{customText['rq-Quiz-nextButton--finish'] || 'Finish'}</button>
-          : <button className={classNames('rq-Quiz-nextButton', customClassNames['rq-Quiz-nextButton'])}
+                    disabled={answers[currentQuestionIndex] === undefined}>{finishButtonText}</button>
+          : <button className={nextButtonClassName}
                     onClick={onNext}
-                    disabled={answers[currentQuestionIndex] === undefined}>{customText['rq-Quiz-nextButton'] || 'Next'}</button>
+                    disabled={answers[currentQuestionIndex] === undefined}>{nextButtonText}</button>
         }
       </div>
     </div>


### PR DESCRIPTION
Makes it possible to customise text in a similar way to how you can customise styling by selecting on classname.

See individual commits for details.

The primary use case is for providing translations (see https://github.com/britishcouncil/tiger-quiz/pull/6)

**This PR represents a `major` version bump since it removes the _progressText_ prop.**
